### PR TITLE
use a side chain compressor before the MB, that gets it's SC from the global output 

### DIFF
--- a/soundsgood.dsp
+++ b/soundsgood.dsp
@@ -177,12 +177,18 @@ with {
 
     lp1p(cf) = si.smooth(ba.tau2pole(1/(2*ma.PI*cf)));
 };
+
+
 // SIDE CHAIN COMPRESSOR
 sc_compressor =
-    ((RMS_compression_gain_N_chan_db(strength,thresh,att,rel,knee,0,link,N)),si.bus(N))
-    : ro.interleave(N,2) : par(i,N,(meter : ba.db2linear)*_)
+    (
+        (ms_enc,ms_enc):
+        (((RMS_compression_gain_N_chan_db(strength,thresh,att,rel,knee,0,link,N)),si.bus(N) )
+         : ro.interleave(N,2) : par(i,N,(meter : ba.db2linear*(1-bypass)+bypass)*_))
+        : ms_dec)
 with {
     N = 2;
+    bypass = checkbox("v:soundsgood/t:expert/h:[7]kneecomp/[1]kneecomp bypass"):si.smoo;
     strength = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[1]kneecomp strength", 1, 0, 1, 0.1);
     thresh = target + vslider("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB][2]kneecomp threshold",init_kneecomp_thresh,-30,0,1);
     threshLim =

--- a/soundsgood.dsp
+++ b/soundsgood.dsp
@@ -189,14 +189,11 @@ sc_compressor =
 with {
     N = 2;
     bypass = checkbox("v:soundsgood/t:expert/h:[7]kneecomp/[1]kneecomp bypass"):si.smoo;
-    strength = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[1]kneecomp strength", 1, 0, 1, 0.1);
+    strength = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[1]kneecomp strength", 1, 0, 4, 0.1);
     thresh = target + vslider("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB][2]kneecomp threshold",init_kneecomp_thresh,-30,0,1);
-    threshLim =
-        // +6;
-        vslider("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB][3]threshLim",0,-30,0,1);
-    att = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[3]kneecomp attack[unit:ms]",10,1,100,1)*0.001;
-    rel = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[4]kneecomp release[unit:ms]",100,1,1000,1)*0.001;
-    knee = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[5]kneecomp knee",12,0,60,1);
+    att = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[3]kneecomp attack[unit:ms]",40,1,100,1)*0.001;
+    rel = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[4]kneecomp release[unit:ms]",200,1,1000,1)*0.001;
+    knee = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[5]kneecomp knee",6,0,30,1);
     link = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[6]kneecomp link", 0.5, 0, 1, 0.1);
     meter = _<: _,( vbargraph("v:soundsgood/t:expert/h:[7]kneecomp/comp[unit:dB]",-20,0)) : attach;
 
@@ -329,9 +326,9 @@ limiter_no_latency =
     co.FFcompressor_N_chan(1,threshLim,0,att,knee*0.25,0,link,meterLim : ba.db2linear,2)
 with {
 
-    threshLim = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB][3]threshLim",0,-30,0,1);
-    att = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[3]kneecomp attack[unit:ms]",10,1,100,1)*0.001;
-    knee = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[5]kneecomp knee",12,0,60,1);
+    threshLim = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB][3]threshLim",init_brickwall_ceiling,-30,0,1);
+    att = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[3]kneecomp attack[unit:ms]",40,1,100,1)*0.001;
+    knee = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[5]kneecomp knee",6,0,30,1);
     link = 1;//vslider("v:soundsgood/t:expert/h:[7]kneecomp/[6]kneecomp link", 0.5, 0, 1, 0.1);
            meterLim =
                _<: _,( ba.linear2db:vbargraph("v:soundsgood/t:expert/h:[7]kneecomp/lim[unit:dB]",-20,0)) : attach;

--- a/soundsgood.dsp
+++ b/soundsgood.dsp
@@ -37,8 +37,7 @@ target = vslider("v:soundsgood/h:easy/[2]Target[unit:dB]", init_leveler_target,-
 // main
 process =
     //tone_generator :
-    si.bus(2)
-    : lufs_meter_in
+    lufs_meter_in
     : dc_filter(2)
 
     : gate_bp
@@ -53,8 +52,8 @@ process =
         : mscomp8i_bp
         : kneecomp_bp
 
-        : limiter_bp
-        : brickwall_bp
+          // : limiter_bp
+          // : brickwall_bp
 
         : lufs_meter_out
     )~(si.bus(2))
@@ -270,19 +269,24 @@ with {
   maxGR = -30;
 };
 
+
 // KNEE COMPRESSOR
 kneecomp_bp = bp2(checkbox("v:soundsgood/t:expert/h:[7]kneecomp/[1]kneecomp bypass"),kneecomp(target));
-kneecomp(target) = ms_enc : co.RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,meterLim,2) : ms_dec : post_gain with {
+kneecomp(target) = ms_enc : co.RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,meterLim,2): post_gain  : ms_dec  with {
 
-    strength = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[1]kneecomp strength", 0.1, 0, 1, 0.1);
-    thresh = target + vslider("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB][2]kneecomp threshold",init_kneecomp_thresh,-12,6,1);
-    threshLim = +6; //vslider("threshLim",3,-12,3,1);
-    att = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[3]kneecomp attack",0.4,0.001,1,0.001);
-    rel = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[4]kneecomp release",0.8,0.01,1,0.001);
-    knee = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[5]kneecomp knee",12,0,12,1);
+    strength = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[1]kneecomp strength", 1, 0, 1, 0.1);
+    thresh = target + vslider("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB][2]kneecomp threshold",init_kneecomp_thresh,-30,0,1);
+    threshLim =
+        // +6;
+        vslider("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB][3]threshLim",0,-30,0,1);
+    att = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[3]kneecomp attack[unit:ms]",10,1,100,1)*0.001;
+    rel = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[4]kneecomp release[unit:ms]",100,1,1000,1)*0.001;
+    knee = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[5]kneecomp knee",12,0,60,1);
     link = vslider("v:soundsgood/t:expert/h:[7]kneecomp/[6]kneecomp link", 0.5, 0, 1, 0.1);
-    meter = _<: _,(ba.linear2db : ma.neg : vbargraph("v:soundsgood/t:expert/h:[7]kneecomp/[unit:dB]",0,3)) : attach;
-    meterLim = _; //_<: _,(ba.linear2db : ma.neg : vbargraph("v:soundsgood/t:expert/h:[7]knee-comp/[unit:dB]",0,3)) : attach;
+    meter = _<: _,( ba.linear2db:vbargraph("v:soundsgood/t:expert/h:[7]kneecomp/comp[unit:dB]",-20,0)) : attach;
+    meterLim =
+        // _;
+        _<: _,( ba.linear2db:vbargraph("v:soundsgood/t:expert/h:[7]kneecomp/lim[unit:dB]",-20,0)) : attach;
 
     //post_gain
     post_gain = par(i,2,_ * g) with {

--- a/soundsgood.dsp
+++ b/soundsgood.dsp
@@ -184,7 +184,7 @@ sc_compressor =
     (
         (ms_enc,ms_enc):
         (((RMS_compression_gain_N_chan_db(strength,thresh,att,rel,knee,0,link,N)),si.bus(N) )
-         : ro.interleave(N,2) : par(i,N,(meter : ba.db2linear*(1-bypass)+bypass)*_))
+         : ro.interleave(N,2) : par(i,N,(meter : post_gain : ba.db2linear*(1-bypass)+bypass)*_))
         : ms_dec)
 with {
     N = 2;
@@ -221,6 +221,10 @@ with {
             s = ba.sec2samp(time):int:max(1);
         };
     };
+    //post_gain
+    post_gain =
+        _+
+        (vslider("v:soundsgood/t:expert/h:[7]kneecomp/[9]kneecomp makeup[unit:dB]", init_kneecomp_postgain,-10,+10,0.5) :si.smoo);
 };
 
 


### PR DESCRIPTION
This allows you to tame short-isch peaks before they hit the MB-compressor, so a loud word doesn't get it's frequency response  messed up by the MB-compressor.

For now, the GUI is WIP; I just re-used the gui elements from the old compressor.
Like in the old comp/limiter, the compressors attack is the limiters release.
The limiter is fully stereo linked, hence the mono meter.
The limiter has a knee of 1/4th of the compressor knee.

If you like this topology, I think we need to give the compressor and limiter their own tabs and maybe give the limiter a separate link and release.. 