### PR TITLE
bypass: use library function

### DIFF
--- a/soundsgood.dsp
+++ b/soundsgood.dsp
@@ -79,10 +79,12 @@ process =
     : peakmeter_out
 ;
 
-// stereo bypass with si.smoo fading
-bp2(sw,pr) =  _,_ <: _,_,pr : (_*sm,_*sm),(_*(1-sm),_*(1-sm)) :> _,_ with {
-    sm = sw : si.smoo;
+// stereo bypass with cross-fade
+bp2(sw,pr) = ba.bypass_fade(ma.SR*fade_time,sw,pr)
+             with {
+  fade_time = 0.01;//seconds
 };
+
 
 // DC FILTER
 dc_blocker_bp = bp2(sw,dc_blocker(2)) with {


### PR DESCRIPTION
This causes the GR meters to return to zero when bypassed;
which can be considered both a feature and a bug,
depending on your POV.

Personally, I find it confusing when the GR meter of a
bypassed processor is moving.